### PR TITLE
pyproject: fix license string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   "Mathieu Tarral <mathieu.tarral@intel.com>",
   "Rowan Hart <rowan.hart@intel.com>",
 ]
-license = {file = "COPYING"}
+license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"


### PR DESCRIPTION
```
1.692 The Poetry configuration is invalid:
1.692   - data.license must be string
```