### PR TITLE
Dockerfile: fix missing dependency libgcc-11-dev (seabios)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ apt-get install -y --no-install-recommends \
   pkg-config libglib2.0-dev libpixman-1-dev \
   libyajl-dev flex bison ninja-build curl rsync cmake \
   flex bison libglib2.0-dev libjson-c-dev libyajl-dev \
-  rsync python3-pip sudo ccache dmidecode
+  rsync python3-pip sudo ccache dmidecode libgcc-11-dev
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
~~~
84.30 make[6]: Entering directory '/code/xen/tools/firmware'
84.52 make -C seabios-dir CC=gcc LD=ld PYTHON=python3 EXTRAVERSION="-Xen" all;
84.52 make[7]: Entering directory '/code/xen/tools/firmware/seabios-dir-remote'
85.15 make[7]: *** No rule to make target '/usr/lib/gcc/x86_64-linux-gnu/11/include/stdarg.h', needed by 'out/src/output.o'.  Stop.
85.15 make[7]: *** Waiting for unfinished jobs....
85.16 make[8]: Entering directory '/code/xen/tools/firmware/seabios-dir-remote'
85.16 make[8]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
85.16   Build Kconfig config file
~~~